### PR TITLE
chore: set minimum release age for dependency updates (1 day)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 1440

--- a/renovate.json
+++ b/renovate.json
@@ -21,5 +21,6 @@
   ],
   "schedule": [
     "every weekday"
-  ]
+  ],
+  "minimumReleaseAge": "1 day"
 }


### PR DESCRIPTION
Sets a 1-day minimum release age for dependency updates, on both levels:

- `minimumReleaseAge: "1 day"` in the Renovate config, so Renovate waits a day after a release before opening an update PR
- `npmMinimalAgeGate: 1440` in `.yarnrc.yml` (Yarn 4.10+), so local/CI resolution also skips releases younger than a day

This keeps us from picking up broken or compromised fresh releases, like oxfmt 0.64.0 did in mikro-orm/nestjs-realworld-example-app#166. Same as mikro-orm/nestjs-realworld-example-app#167.
